### PR TITLE
Invert cuda inclusion

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,7 +17,7 @@ source:
     - conda.diff
 
 build:
-  number: 1
+  number: 2
   # We build from source on Unix and re-package binaries on windows
   #  Yandex supplies whl files on PyPI for:
   # - Win-64: Python 3.7, 3.8, 3.9, 3.10, 3.11, 3.12
@@ -76,8 +76,7 @@ requirements:
     - python-graphviz
     #python-graphviz avoids the pip check error
   run_constrained:
-    # make sure the non CUDA build does not get installed when the user has CUDA enabled
-    - __cuda <0.0a0  # [unix and cuda_compiler_version == "None"]
+    - __cuda  # [cuda_compiler != "None"]
     # relax jupyterlab version constraints from those used in the build
     # catboost only works properly with jupyterlab 3.x for now
     # but we don't want to constrain users to these versions as it only affects catboost visualization

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,9 +1,12 @@
 {% set version = "1.2.7" %}
 
+{% set build_num = 2 %}
+
 {% if cuda_compiler_version == "None" %}
 {% set cuda_major = 0 %}
 {% else %}
 {% set cuda_major = environ.get("cuda_compiler_version", "11.8").split(".")[0] | int %}
+{% set build_num = build_num + 100 %}
 {% endif %}
 
 package:
@@ -17,7 +20,7 @@ source:
     - conda.diff
 
 build:
-  number: 2
+  number: {{ build_num }}
   # We build from source on Unix and re-package binaries on windows
   #  Yandex supplies whl files on PyPI for:
   # - Win-64: Python 3.7, 3.8, 3.9, 3.10, 3.11, 3.12
@@ -35,6 +38,9 @@ build:
   skip: True  # [win and cuda_compiler_version != "None"]
   string: cuda{{ cuda_compiler_version | replace('.', '') }}_py{{ CONDA_PY }}h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}  # [unix and cuda_compiler_version != "None"]
   string: cpu_py{{ CONDA_PY }}h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}                                                 # [unix and cuda_compiler_version == "None"]
+  # de-prioritize the CPU variants
+  track_features:     # [cuda_compiler_version == "None"]
+    - catboost_cpu    # [cuda_compiler_version == "None"]
 
 requirements:
   build:


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->


Currently, you cannot install catboost cpu on a gpu-enabled system. This logic is wrongly inverted - you should always be able to install catboost cpu on a gpu-enabled system. With the inverse here, you cannot install gpu catboost on a cpu-only system, unless you set the `CONDA_OVERRIDE_CUDA` variable. Thus, with this code, you can install either-on-either instead of being restricted. 