### PR TITLE
Remove 'shap' package dependency from tests to get rid of a circular dependency between 'catboost' and 'shap' packages. Fixes #132

### DIFF
--- a/recipe/conda.diff
+++ b/recipe/conda.diff
@@ -46,6 +46,43 @@ index 7cb81ff061..a2fb977b04 100644
  set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
  set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
  set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
+diff --git a/catboost/pytest/smoke_tests/classification_tutorial_cpu.py b/catboost/pytest/smoke_tests/classification_tutorial_cpu.py
+index 0d140f566c..3ff63efbf7 100644
+--- a/catboost/pytest/smoke_tests/classification_tutorial_cpu.py
++++ b/catboost/pytest/smoke_tests/classification_tutorial_cpu.py
+@@ -42,7 +42,6 @@ except:
+ 
+ #!pip install --user --upgrade catboost
+ #!pip install --user --upgrade ipywidgets
+-#!pip install shap
+ #!pip install sklearn
+ #!pip install --upgrade numpy
+ #!jupyter nbextension enable --py widgetsnbextension
+@@ -643,24 +642,6 @@ shap_values = shap_values[:,:-1]
+ print(shap_values.shape)
+ 
+ 
+-import shap
+-shap.initjs()
+-shap.force_plot(expected_value, shap_values[3,:], X.iloc[3,:], show=False)
+-
+-
+-import shap
+-shap.initjs()
+-shap.force_plot(expected_value, shap_values[91,:], X.iloc[91,:], show=False)
+-
+-
+-shap.summary_plot(shap_values, X, show=False)
+-
+-
+-X_small = X.iloc[0:200]
+-shap_small = shap_values[:200]
+-shap.force_plot(expected_value, shap_small, X_small, show=False)
+-
+-
+ ### Feature evaluation
+ 
+ 
 diff --git a/catboost/python-package/pyproject.toml b/catboost/python-package/pyproject.toml
 index e864b0738d..d49f6f20d6 100644
 --- a/catboost/python-package/pyproject.toml

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set version = "1.2.8" %}
 
-{% set build_num = 2 %}
+{% set build_num = 3 %}
 
 {% if cuda_compiler_version == "None" %}
 {% set cuda_major = 0 %}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -103,7 +103,6 @@ test:
   requires:
     - pip
     - scikit-learn
-    - shap
     - traitlets
     - ipython
     - ipywidgets >=7.0,<9.0


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
